### PR TITLE
fix warning React does not recognize computedMatch

### DIFF
--- a/client/Routes.js
+++ b/client/Routes.js
@@ -9,13 +9,11 @@ export default class Routes extends Component {
   render() {
     return (
       <Switch>
-        <div id="main">
-          <Route exact path="/" component={HomePage} />
-          <Route path="/SongsList" component={AllSongs} />
-          <Route path="/Login" component={Login} />
-          <Route path="/SignUp" component={Signup} />
-          <Route path="/Artist" component={ArtistUpload} />
-        </div>
+        <Route exact path="/" component={HomePage} />
+        <Route path="/SongsList" component={AllSongs} />
+        <Route path="/Login" component={Login} />
+        <Route path="/SignUp" component={Signup} />
+        <Route path="/Artist" component={ArtistUpload} />
       </Switch>
     );
   }


### PR DESCRIPTION
The only children of a Switch should be Routes; the div was causing the error. There is already a div id="main" in index.html